### PR TITLE
Refactor Timetag

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -110,7 +110,7 @@ func (b *Bundle) MarshalBinary() ([]byte, error) {
 // Bundle.
 func NewBundle(time time.Time) *Bundle {
 	return &Bundle{
-		Timetag:  *NewTimetag(time),
+		Timetag:  NewTimetagFromTime(time),
 		Messages: []*Message{},
 		Bundles:  []*Bundle{},
 	}

--- a/message.go
+++ b/message.go
@@ -86,7 +86,7 @@ func (msg *Message) String() string {
 
 		case Timetag:
 
-			s.WriteString(fmt.Sprintf(" %d", argType.TimeTag()))
+			s.WriteString(fmt.Sprintf(" %d", Timetag(argType)))
 		}
 	}
 

--- a/packet.go
+++ b/packet.go
@@ -57,7 +57,7 @@ func readBundle(reader *bufio.Reader, start *int, end int) (*Bundle, error) {
 	*start += 8
 
 	// Create a new bundle
-	bundle := NewBundle(timetagToTime(timeTag))
+	bundle := NewBundle(timetagToTime(Timetag(timeTag)))
 
 	// Read until the end of the buffer
 	for *start < end {
@@ -197,7 +197,7 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 			}
 
 			*start += 8
-			msg.Append(*NewTimetagFromTimetag(tt))
+			msg.Append(Timetag(tt))
 
 		case 'N': // nil
 			msg.Append(nil)

--- a/timetag.go
+++ b/timetag.go
@@ -16,67 +16,55 @@ const (
 // specify the number of seconds since midnight on January 1, 1900, and the
 // last 32 bits specify fractional parts of a second to a precision of about
 // 200 picoseconds. This is the representation used by Internet NTP timestamps.
-type Timetag struct {
-	timeTag uint64 // The acutal time tag
-	time    time.Time
+type Timetag uint64
+
+// NewTimetag returns a new OSC time tag object with the time set to now.
+func NewTimetag() Timetag {
+	return timeToTimetag(time.Now().UTC())
 }
 
 // NewTimetag returns a new OSC time tag object.
-func NewTimetag(timeStamp time.Time) *Timetag {
-	return &Timetag{
-		time:    timeStamp,
-		timeTag: timeToTimetag(timeStamp),
-	}
+func NewTimetagFromTime(timeStamp time.Time) Timetag {
+	return timeToTimetag(timeStamp)
 }
 
-// NewTimetagFromTimetag creates a new Timetag from the given `timetag`.
-func NewTimetagFromTimetag(timetag uint64) *Timetag {
-	time := timetagToTime(timetag)
-	return NewTimetag(time)
+// NewImmediateTimetag creates an OSC Time Tag with only the least significant bit set.
+// The time tag value consisting of 63 zero bits followed by a one in the least signifigant bit is a special case meaning “immediately.”
+func NewImmediateTimetag() Timetag {
+	return Timetag(1)
 }
 
 // Time returns the time.
-func (t *Timetag) Time() time.Time {
-	return t.time
+func (t Timetag) Time() time.Time {
+	return timetagToTime(t)
 }
 
 // FractionalSecond returns the last 32 bits of the OSC time tag. Specifies the
 // fractional part of a second.
-func (t *Timetag) FractionalSecond() uint32 {
-	return uint32(t.timeTag << 32)
+func (t Timetag) FractionalSecond() uint32 {
+	return uint32(t << 32)
 }
 
 // SecondsSinceEpoch returns the first 32 bits (the number of seconds since the
 // midnight 1900) from the OSC time tag.
-func (t *Timetag) SecondsSinceEpoch() uint32 {
-	return uint32(t.timeTag >> 32)
-}
-
-// TimeTag returns the time tag value.
-func (t *Timetag) TimeTag() uint64 {
-	return t.timeTag
+func (t Timetag) SecondsSinceEpoch() uint32 {
+	return uint32(t >> 32)
 }
 
 // MarshalBinary converts the OSC time tag to a byte array.
-func (t *Timetag) MarshalBinary() ([]byte, error) {
+func (t Timetag) MarshalBinary() ([]byte, error) {
 	data := new(bytes.Buffer)
-	err := binary.Write(data, binary.BigEndian, t.timeTag)
+	err := binary.Write(data, binary.BigEndian, t)
 	return data.Bytes(), err
-}
-
-// SetTime sets the value of the OSC time tag.
-func (t *Timetag) SetTime(time time.Time) {
-	t.time = time
-	t.timeTag = timeToTimetag(time)
 }
 
 // ExpiresIn calculates the number of seconds until the current time is the same as the value of the time tag.
 // It returns zero if the value of the time tag is in the past.
-func (t *Timetag) ExpiresIn() time.Duration {
-	if t.timeTag <= 1 {
+func (t Timetag) ExpiresIn() time.Duration {
+	if t <= 1 {
 		return 0
 	}
-	if d := time.Until(timetagToTime(t.timeTag)); d > 0 {
+	if d := time.Until(timetagToTime(t)); d > 0 {
 		return d
 	}
 
@@ -84,15 +72,11 @@ func (t *Timetag) ExpiresIn() time.Duration {
 }
 
 // timeToTimetag converts the given time to an OSC time tag.
-//
-// The time tag value consisting of 63 zero bits followed by a one in the least
-// significant bit is a special case meaning "immediately.".
-func timeToTimetag(time time.Time) (timetag uint64) {
-	timetag = uint64((secondsFrom1900To1970 + time.Unix()) << 32)
-	return (timetag + uint64(uint32(time.Nanosecond())))
+func timeToTimetag(time time.Time) (timetag Timetag) {
+	return (Timetag(secondsFrom1900To1970+time.Unix()) << 32) + Timetag(time.Nanosecond())
 }
 
 // timetagToTime converts the given timetag to a time object.
-func timetagToTime(timetag uint64) (t time.Time) {
+func timetagToTime(timetag Timetag) (t time.Time) {
 	return time.Unix(int64((timetag>>32)-secondsFrom1900To1970), int64(timetag&0xffffffff))
 }

--- a/timetag_test.go
+++ b/timetag_test.go
@@ -8,24 +8,23 @@ import (
 )
 
 func TestTimetag(t *testing.T) {
-	t.Run("should create a TimeTag", func(t *testing.T) {
-		ti := time.Now()
-		tt := NewTimetag(ti)
-
-		assert.Equal(t, ti, tt.Time())
+	t.Run("should create an immediate timetag", func(t *testing.T) {
+		tt := NewImmediateTimetag()
+		assert.Equal(t, tt.Time(), time.Date(1900, time.January, 1, 1, 0, 0, 1, time.Local))
 	})
 
-	t.Run("should create a timetag from timetag", func(t *testing.T) {
+	t.Run("should create a TimeTag", func(t *testing.T) {
 		ti := time.Now()
-		tt := NewTimetagFromTimetag(timeToTimetag(ti))
-
-		assert.True(t, ti.Equal(tt.time))
+		tt := NewTimetagFromTime(ti)
+		assert.True(t, tt.Time().Equal(ti))
 	})
 
 	t.Run("should expires in about a minute", func(t *testing.T) {
 		ti := time.Now().Add(time.Minute)
-		tt := NewTimetag(ti)
+		tt := NewTimetagFromTime(ti)
 
-		assert.True(t, tt.ExpiresIn() > 59*time.Second)
+		actual := tt.ExpiresIn().Round(time.Millisecond)
+
+		assert.True(t, actual == 60*time.Second)
 	})
 }

--- a/timetag_test.go
+++ b/timetag_test.go
@@ -10,12 +10,14 @@ import (
 func TestTimetag(t *testing.T) {
 	t.Run("should create an immediate timetag", func(t *testing.T) {
 		tt := NewImmediateTimetag()
+
 		assert.Equal(t, tt.Time(), time.Date(1900, time.January, 1, 1, 0, 0, 1, time.Local))
 	})
 
 	t.Run("should create a TimeTag", func(t *testing.T) {
 		ti := time.Now()
 		tt := NewTimetagFromTime(ti)
+
 		assert.True(t, tt.Time().Equal(ti))
 	})
 
@@ -26,5 +28,14 @@ func TestTimetag(t *testing.T) {
 		actual := tt.ExpiresIn().Round(time.Millisecond)
 
 		assert.True(t, actual == 60*time.Second)
+	})
+
+	t.Run("should marshall binary an immediate tag", func(t *testing.T) {
+		tt := NewImmediateTimetag()
+
+		actual, err := tt.MarshalBinary()
+		assert.Nil(t, err)
+
+		assert.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 1}, actual)
 	})
 }


### PR DESCRIPTION
Pull request for #8. 

Now Timetag is a simple uint64 type. I added NewImmediateTimetag() method like in osc documentation that specify: 
```
The time tag value consisting of 63 zero bits followed by a one in the least signifigant bit is a special case meaning “immediately.”
```