### PR TITLE
Fix regex msghandler

### DIFF
--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -5,7 +5,152 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestDispatch(t *testing.T) {
+	d := NewStandardDispatcher()
+
+	handlerName := [4]string{"/message", "/message/01", "/message/03", "*"}
+	b := [4]bool{false, false, false, false}
+
+	err := d.AddMsgHandler(handlerName[0], func(msg *Message) {
+		b[0] = true
+	})
+	assert.Nil(t, err)
+	err = d.AddMsgHandler(handlerName[1], func(msg *Message) {
+		b[1] = true
+	})
+	assert.Nil(t, err)
+	err = d.AddMsgHandler(handlerName[2], func(msg *Message) {
+		b[2] = true
+	})
+	assert.Nil(t, err)
+	err = d.AddMsgHandler(handlerName[3], func(msg *Message) {
+		b[3] = true
+	})
+	assert.Nil(t, err)
+
+	// error ERROR_OSC_ADDRESS_EXISTS
+	err = d.AddMsgHandler(handlerName[1], func(msg *Message) {
+		b[1] = true
+	})
+	assert.NotNil(t, err)
+
+	t.Run("dispatch message", func(t *testing.T) {
+
+		tc := []struct {
+			desc string
+			msg  string
+			b    [4]bool
+			err  bool
+		}{
+			{
+				"match everything",
+				"*",
+				[4]bool{true, true, true, true},
+				false,
+			},
+			{
+				"match /message",
+				"/message",
+				[4]bool{true, false, false, true},
+				false,
+			},
+			{
+				"match [1-3]",
+				"/message/0[1-3]",
+				[4]bool{false, true, true, true},
+				false,
+			},
+			{
+				"don't match",
+				"/message/01/01",
+				[4]bool{false, false, false, true},
+				false,
+			},
+			{
+				"Regex error",
+				"}/",
+				[4]bool{false, false, false, false},
+				true,
+			},
+		}
+
+		err = nil
+		for _, tt := range tc {
+			msg := NewMessage(tt.msg)
+			err = d.Dispatch(msg)
+			if tt.err {
+				assert.NotNil(t, err, "%s: msgPath = '%s', expect error", tt.desc, tt.msg)
+			} else {
+				assert.Nil(t, err, "%s: msgPath = '%s', expect no error", tt.desc, tt.msg)
+			}
+
+			for i, got := range b {
+				if got != tt.b[i] {
+					t.Errorf("%s: msgPath='%v', handlerFunc='%s', got  = '%t', want = '%t'", tt.desc, tt.msg, handlerName[i], got, tt.b[i])
+				}
+			}
+
+			b = [4]bool{false, false, false, false}
+			err = nil
+		}
+	})
+	t.Run("dispatch bundle", func(t *testing.T) {
+
+		b = [4]bool{false, false, false, false}
+
+		bundle := NewBundle(time.Now())
+
+		// 1 bundle, 2 messages
+		err := bundle.Append(NewMessage(handlerName[1], ""))
+		assert.Nil(t, err)
+		err = bundle.Append(NewMessage(handlerName[2], "test2"))
+		assert.Nil(t, err)
+
+		err = d.Dispatch(bundle)
+		assert.Nil(t, err)
+
+		assert.False(t, b[0], "check handlerFunc %v", handlerName[0])
+		assert.True(t, b[1], "check handlerFunc %v", handlerName[1])
+		assert.True(t, b[2], "check handlerFunc %v", handlerName[2])
+		assert.True(t, b[3], "check handlerFunc %v", handlerName[3])
+
+		// bundle2 with 2 bundles: bundle(2 messages), bundle3(1 message)
+		bundle2 := NewBundle(bundle.Timetag.Time())
+		err = bundle2.Append(bundle)
+		assert.Nil(t, err)
+
+		bundle3 := NewBundle(time.Now())
+		err = bundle2.Append(bundle3)
+		assert.Nil(t, err)
+		err = bundle3.Append(NewMessage(handlerName[0]))
+		assert.Nil(t, err)
+
+		err = d.Dispatch(bundle2)
+		assert.Nil(t, err)
+
+		assert.True(t, b[0], "check handlerFunc %v", handlerName[0])
+		assert.True(t, b[1], "check handlerFunc %v", handlerName[1])
+		assert.True(t, b[2], "check handlerFunc %v", handlerName[2])
+		assert.True(t, b[3], "check handlerFunc %v", handlerName[3])
+
+		// bundle: test error handling
+		err = bundle.Append(NewMessage("}/"))
+		assert.Nil(t, err)
+		err = d.Dispatch(bundle)
+		assert.NotNil(t, err)
+
+		// bundle3: test error handling
+		err = bundle3.Append(NewMessage("}/"))
+		assert.Nil(t, err)
+		err = d.Dispatch(bundle2)
+		assert.NotNil(t, err)
+
+	})
+}
 
 func TestAddMsgHandler(t *testing.T) {
 	d := NewStandardDispatcher()

--- a/message.go
+++ b/message.go
@@ -19,8 +19,22 @@ type Message struct {
 // var _ Packet = (*Message)(nil)
 
 // Append appends the given arguments to the arguments list.
-func (msg *Message) Append(args ...interface{}) {
+func (msg *Message) Append(args ...interface{}) error {
+	// check types of args
+
+	for _, arg := range args {
+		switch t := arg.(type) {
+
+		// OSC types are ok
+		case bool, int32, int64, float32, float64, string, nil, []byte, Timetag: // do nothing
+		// type is not an OSC type
+		default:
+			return fmt.Errorf("unsupported type: %T", t)
+		}
+	}
+
 	msg.Arguments = append(msg.Arguments, args...)
+	return nil
 }
 
 // Equals returns true if the given OSC Message `m` is equal to the current OSC
@@ -44,7 +58,13 @@ func (msg *Message) ClearData() {
 // Match returns true, if the OSC address pattern of the OSC Message matches the given
 // address. The match is case sensitive!
 func (msg *Message) Match(addr string) bool {
-	return getRegEx(msg.Address).MatchString(addr)
+	regex, err := getRegEx(msg.Address)
+	if err != nil {
+		if err != nil {
+			panic("regexp: Compile(msg.Address): " + err.Error())
+		}
+	}
+	return regex.MatchString(addr)
 }
 
 // typeTags returns the type tag string.
@@ -162,7 +182,6 @@ func (msg *Message) MarshalBinary() ([]byte, error) {
 
 		case int64:
 			typetags[i+1] = 'h'
-
 			err = binary.Write(payload, binary.BigEndian, t)
 			if err != nil {
 				return nil, err
@@ -207,6 +226,13 @@ func (msg *Message) MarshalBinary() ([]byte, error) {
 }
 
 // NewMessage returns a new Message. The address parameter is the OSC address.
+// if args has invalid types it return nil
 func NewMessage(addr string, args ...interface{}) *Message {
-	return &Message{Address: addr, Arguments: args}
+	msg := &Message{Address: addr}
+	err := msg.Append(args...)
+	if err != nil {
+		panic(err)
+	}
+
+	return msg
 }

--- a/server.go
+++ b/server.go
@@ -52,8 +52,13 @@ func (s *Server) serve(c net.PacketConn) error {
 
 			return err
 		}
-
-		go s.Dispatcher.Dispatch(msg)
+		errChan := make(chan error)
+		go func() {
+			errChan <- s.Dispatcher.Dispatch(msg)
+		}()
+		if err := <-errChan; err != nil {
+			return err
+		}
 	}
 }
 

--- a/serverclient.go
+++ b/serverclient.go
@@ -43,30 +43,37 @@ func (sc *ServerAndClient) Send(packet Packet) (err error) {
 	return err
 }
 
-// SendMsg sends a OSC Message (all int types konverted to int32)
+// SendMsg sends a OSC Message (all int types converted to int32)
+// Default int is int32, include int values in range of int32
+// If you need a int value in range of int64 convert the arg to int64
 func (sc *ServerAndClient) SendMsg(adr string, args ...any) error {
 	var a []any
 
 	for _, arg := range args {
-		switch arg.(type) {
+		switch t := arg.(type) {
 		case int8:
-			a = append(a, int32(arg.(int8)))
+			a = append(a, int32(t))
 		case uint8:
-			a = append(a, int32(arg.(uint8)))
+			a = append(a, int32(t))
+		case int16:
+			a = append(a, int32(t))
+		case uint16:
+			a = append(a, int32(t))
 		case int:
-			if (arg.(int) <= math.MaxInt32) && (arg.(int) >= math.MinInt32) {
-				a = append(a, int32(arg.(int)))
+			if (t <= math.MaxInt32) && (t >= math.MinInt32) {
+				a = append(a, int32(t))
 			} else {
-				return fmt.Errorf("int32 %d out of range", arg.(int))
+				return fmt.Errorf("int32 %d out of range", t)
 			}
-
-		default:
+		case bool, int64, int32, float32, float64, string, nil, []byte, Timetag:
 			a = append(a, arg)
+		default:
+
 		}
 
 	}
 
-	return sc.Send(NewMessage(adr, a...))
+	return sc.Send(&Message{Address: adr, Arguments: a})
 }
 
 // ListenAndServe listen and serve as an OSC Server

--- a/serverclient_test.go
+++ b/serverclient_test.go
@@ -1,12 +1,13 @@
 package osc_test
 
 import (
-	"github.com/crgimenes/go-osc"
-	"github.com/stretchr/testify/assert"
 	"net"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/crgimenes/go-osc"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -24,8 +25,35 @@ func TestServerAndClient(t *testing.T) {
 		wait := sync.WaitGroup{}
 		wait.Add(1)
 
-		var d float64 = 0.0
-		var i int32 = 0
+		var pingF64 = 0.0
+
+		var boolTrue = false
+		var boolFalse = true
+		var i32 int32 = 0
+		var i64 int64 = 0
+		var f32 float32 = 0.0
+		var f64 float64 = 0.0
+		var strTest string = ""
+		var strEmpty string = "e"
+		var i int = 0
+		var null any = 10
+		var array []byte = []byte{10, 11, 12}
+		var timetag osc.Timetag
+
+		const (
+			cBoolTrue          = true
+			cBoolFalse         = false
+			cI32       int32   = 2
+			cI64       int64   = 3
+			cF32       float32 = 4.0
+			cF64       float64 = 5.0
+			cStrTest   string  = "6test"
+			cStrEmpty  string  = ""
+			cI         int     = 8
+			// nil
+		)
+		var cArray []byte = []byte{10, 48}
+		const cTimetag osc.Timetag = 16818286200017484014
 
 		addr1, err := net.ResolveUDPAddr("udp", "127.0.0.1:8000")
 		if err != nil {
@@ -40,19 +68,12 @@ func TestServerAndClient(t *testing.T) {
 		d1 := osc.NewStandardDispatcher()
 		app1 := osc.NewServerAndClient(d1)
 		err = app1.NewConn(addr2, addr1)
-		if err != nil {
-			t.Error(err)
-		}
-		defer func() {
-			err := app1.Close()
-			if err != nil {
-				t.Error(err)
-			}
-		}()
 
 		err = d1.AddMsgHandler(ping, func(msg *osc.Message) {
-			d = msg.Arguments[0].(float64)
-			err = app1.SendMsg(pong, 2)
+			pingF64 = msg.Arguments[0].(float64)
+
+			err = app1.SendMsg(pong, cBoolTrue, cBoolFalse, cI32, cI64, cF32, cF64, cStrTest, cStrEmpty, cI, nil, cArray, cTimetag)
+
 			if err != nil {
 				t.Error(err)
 			}
@@ -70,7 +91,20 @@ func TestServerAndClient(t *testing.T) {
 
 		d2 := osc.NewStandardDispatcher()
 		err = d2.AddMsgHandler(pong, func(msg *osc.Message) {
-			i = msg.Arguments[0].(int32)
+
+			boolTrue = msg.Arguments[0].(bool)
+			boolFalse = msg.Arguments[1].(bool)
+			i32 = msg.Arguments[2].(int32)
+			i64 = msg.Arguments[3].(int64)
+			f32 = msg.Arguments[4].(float32)
+			f64 = msg.Arguments[5].(float64)
+			strTest = msg.Arguments[6].(string)
+			strEmpty = msg.Arguments[7].(string)
+			i = int(msg.Arguments[8].(int32))
+			null = msg.Arguments[9]
+			array = msg.Arguments[10].([]byte)
+			timetag = msg.Arguments[11].(osc.Timetag)
+
 			wait.Done()
 		})
 		if err != nil {
@@ -103,8 +137,20 @@ func TestServerAndClient(t *testing.T) {
 		wait.Wait()
 
 		// check if send and receive are the same
-		assert.Equal(t, 1.0, d)
-		assert.Equal(t, int32(2), i)
+		assert.Equal(t, 1.0, pingF64)
+
+		assert.Equal(t, cBoolTrue, boolTrue)
+		assert.Equal(t, cBoolFalse, boolFalse)
+		assert.Equal(t, cI32, i32)
+		assert.Equal(t, cI64, i64)
+		assert.Equal(t, cF32, f32)
+		assert.Equal(t, cF64, f64)
+		assert.Equal(t, cStrTest, strTest)
+		assert.Equal(t, cStrEmpty, strEmpty)
+		assert.Equal(t, cI, i)
+		assert.Nil(t, null)
+		assert.Equal(t, cArray, array)
+		assert.Equal(t, cTimetag, timetag)
 
 		done <- true
 	}()

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,12 @@
 package osc
 
 import (
+	"math"
 	"regexp"
 	"strings"
 )
+
+const IsInt64 = math.MaxInt == math.MaxInt64
 
 // addressExists returns true if the OSC address `addr` is found in `handlers`.
 func addressExists(addr string, handlers map[string]Handler) bool {
@@ -17,7 +20,7 @@ func addressExists(addr string, handlers map[string]Handler) bool {
 
 // getRegEx compiles and returns a regular expression object for the given
 // address `pattern`.
-func getRegEx(pattern string) *regexp.Regexp {
+func getRegEx(pattern string) (*regexp.Regexp, error) {
 	for _, trs := range []struct {
 		old, new string
 	}{
@@ -31,9 +34,10 @@ func getRegEx(pattern string) *regexp.Regexp {
 		{"?", "."},  // Change a '?' to '.'
 	} {
 		pattern = strings.Replace(pattern, trs.old, trs.new, -1)
+		pattern = "^" + pattern + "$"
 	}
 
-	return regexp.MustCompile(pattern)
+	return regexp.Compile(pattern)
 }
 
 // getTypeTag returns the OSC type tag for the given argument.


### PR DESCRIPTION
This is a fix for #17 -> "Support for OSC address pattern including '*', '?', '{,}' and '[]' wildcards" is ok now

During work I found a problem with the error handling in the function getRegEx (used by Match -> dispatch function). If the dispatcher receive a incorrect OSC Message maybe it throws a panic. I think the better way is handle this with an error. 
 
For a better performance the getRegEx function call is only need 1 per message.   

I also found a problem with the use of integer types in function SendMsg and fix that.

The test coverage is now 81.1% of statements.